### PR TITLE
Release/2.1.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@
 ///////////////////////////////////////
 
 ----------Added features on v2.1.0-----------
-- Added Stream filte for Smash.gg thumbnail generation;
+- Added Stream filter for Smash.gg thumbnail generation;
 - Can assign different fighter image settings for each tournament;
 - Added log support to track application usage for debug analysis;
 - Fixed issue were Rosalina, Young Link and Incineroar would not show their preview icons;

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.2</version>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.2</version>
+            <version>2.14.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
----------Added features on v2.1.0-----------
- Added Stream filter for Smash.gg thumbnail generation;
- Can assign different fighter image settings for each tournament;
- Added log support to track application usage for debug analysis;
- Fixed issue were Rosalina, Young Link and Incineroar would not show their preview icons;
- Fixed issue with fonts when no font styling (bold and italic) was selected, which would not allow thumbnail generation;
- Kazuya added to the roster;
- Sora added to the roster.