### PR TITLE
Release/2.1.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@
 ///////////////////////////////////////
 
 ----------Added features on v2.1.0-----------
-- Added Stream filte for Smash.gg thumbnail generation;
+- Added Stream filter for Smash.gg thumbnail generation;
 - Can assign different fighter image settings for each tournament;
 - Added log support to track application usage for debug analysis;
 - Fixed issue were Rosalina, Young Link and Incineroar would not show their preview icons;

--- a/README.txt
+++ b/README.txt
@@ -2,17 +2,28 @@
 //          0.Release Notes          //
 ///////////////////////////////////////
 
+----------Added features on v2.1.0-----------
+- Added Stream filte for Smash.gg thumbnail generation;
+- Can assign different fighter image settings for each tournament;
+- Added log support to track application usage for debug analysis;
+- Fixed issue were Rosalina, Young Link and Incineroar would not show their preview icons;
+- Fixed issue with fonts when no font styling (bold and italic) was selected, which would not allow thumbnail generation;
+- Kazuya added to the roster;
+- Sora added to the roster.
+
+
+
 ----------Added features on v2.0.0-----------
-- Thumbnails can now be generated for Smash.gg tournaments
-- Tournament settings can be created, edited or deleted.
-- Menu bar added to initial page to select Thumbnail Generator's functionalities
+- Thumbnails can now be generated for Smash.gg tournaments;
+- Tournament settings can be created, edited or deleted;
+- Menu bar added to initial page to select Thumbnail Generator's functionalities.
 
 
 
 ----------Added features on v1.4.0-----------
-- Scroll pane added to tournament list
-- Updated Falco horizontal offset from -10 to 60
-- Sephiroth added to the roster.
+- Scroll pane added to tournament list;
+- Updated Falco horizontal offset from -10 to 60;
+- Sephiroth added to the roster;
 - Pyra/Mythra added to the roster.
 
 
@@ -28,8 +39,8 @@
 
 
 ----------Added features on v1.2.2-----------
-- Min Min added to the roster.
-- Added Tiamat as a league
+- Min Min added to the roster;
+- Added Tiamat as a league.
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.2</version>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.2</version>
+            <version>2.14.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tgen</groupId>
     <artifactId>thumbnail-generator</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/thumbnail/generate/Thumbnail.java
+++ b/src/main/java/thumbnail/generate/Thumbnail.java
@@ -66,13 +66,14 @@ public class Thumbnail {
     private static BufferedImage generateThumbnail(Tournament tournament, ImageSettings imageSettings, boolean locally, String round, String date, Fighter... fighters)
             throws LocalImageNotFoundException, OnlineImageNotFoundException,
             FontNotFoundException, FighterImageSettingsNotFoundException {
-
+        LOGGER.debug("*********************************************************************************************");
         LOGGER.debug("Creating thumbnail with following parameters:");
         LOGGER.debug("Tournament -> {}", tournament.getName());
         LOGGER.debug("Player 1 -> {}", fighters[0].toString());
         LOGGER.debug("Player 2 -> {}", fighters[1].toString());
         LOGGER.debug("Round -> {}", round);
         LOGGER.debug("Date -> {}", date);
+        LOGGER.debug("*********************************************************************************************");
 
         saveLocally = locally;
         thumbnail = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);


### PR DESCRIPTION
----------Added features on v2.1.0-----------
- Added Stream filter for Smash.gg thumbnail generation;
- Can assign different fighter image settings for each tournament;
- Added log support to track application usage for debug analysis;
- Fixed issue were Rosalina, Young Link and Incineroar would not show their preview icons;
- Fixed issue with fonts when no font styling (bold and italic) was selected, which would not allow thumbnail generation;
- Kazuya added to the roster;
- Sora added to the roster.