### PR TITLE
Bugfix - Upper cased Round on single thumbnail

### DIFF
--- a/src/main/java/thumbnailgenerator/ui/controller/ThumbnailGeneratorController.java
+++ b/src/main/java/thumbnailgenerator/ui/controller/ThumbnailGeneratorController.java
@@ -155,7 +155,7 @@ public class ThumbnailGeneratorController implements Initializable {
                 .game(getGame())
                 .imageSettings(imageSettings)
                 .locally(saveLocally.isSelected())
-                .round(round.getText().toUpperCase())
+                .round(round.getText())
                 .date(date.getText())
                 .players(
                         Thumbnail.createPlayerList(


### PR DESCRIPTION
Removed upper case conversion to "Round" in single thumbnail generation

Related issue:
 - https://github.com/jonborg/ThumbnailGenerator/issues/94