### PR TITLE
Release/4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,11 +889,16 @@ Thumbnails are saved in **/generated_top8** folder.
 
 
 ### Release Notes
+#### v4.5.0
+- Added 2XKO as a selectable game;
+- Added Start.GG generation for GBFVR;
+- Fixed issue with Start.GG generation where not all sets were being analysed.
+
 #### v4.4.1
-- Added Wilnas from GBFVR
-- Fixed issue where round was always written upper case during single thumbnail generation
-- Fixed issue where characters were not flip when character flip was set to true when using mirrorPlayer2.json
-- Fixed issue where thumbnail text would randomly use incorrect size during multi thumbnail generation
+- Added Wilnas from GBFVR;
+- Fixed issue where round was always written upper case during single thumbnail generation;
+- Fixed issue where characters were not flip when character flip was set to true when using mirrorPlayer2.json;
+- Fixed issue where thumbnail text would randomly use incorrect size during multi thumbnail generation.
 
 #### v4.4.0
 - Added July 2025 DLC characters;

--- a/pom.xml
+++ b/pom.xml
@@ -6,17 +6,16 @@
 
     <groupId>com.tgen</groupId>
     <artifactId>thumbnail-generator</artifactId>
-    <version>4.4.1</version>
+    <version>4.5.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jdk.version>11</jdk.version>
         <project.version>${project.version}</project.version>
-        <file.version>4.4.1.0</file.version>
+        <file.version>4.5.0.0</file.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     </properties>
-
 
     <dependencies>
         <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ top8.path.save=generated_top8/
 
 character-image.local-save.path=assets/characters/
 character-image.base-url=https://raw.githubusercontent.com/jonborg/ThumbnailGeneratorCharacterImageRepository/refs/heads
-character-image.version.main=/feature/2xko
+character-image.version.main=/v4.5.0
 character-image.version.backup=/master
 character-image.ssbu.render.path=/ssbu/render
 character-image.ssbu.mural.path=/ssbu/mural


### PR DESCRIPTION
- Added 2XKO as a selectable game;
- Added Start.GG generation for GBFVR;
- Fixed issue with Start.GG generation where not all sets were being analysed.