### PR TITLE
Release/4.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,17 @@ Thumbnails are saved in **/generated_top8** folder.
 
 
 ### Release Notes
+#### v4.5.1
+- Adjusted multi character detection on Start.GG generation to be compatible with 2XKO;
+- Added Galvan from ROA2;
+- Added C. Viper from SF6;
+- Added Armor King from Tekken 8;
+- Added Lucy from Guilty Gear Strive;
+- Added Joe Higashi and Chun-li from FFCOTW;
+- Added Meg from GBFVR;
+- Added Teemo and Warwick from 2XKO;
+- Added random character selection to ROA2, SF6, TEKKEN 8, FFCOTW and 2XKO.
+
 #### v4.5.0
 - Added 2XKO as a selectable game;
 - Added Start.GG generation for GBFVR;

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>com.tgen</groupId>
     <artifactId>thumbnail-generator</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jdk.version>11</jdk.version>
         <project.version>${project.version}</project.version>
-        <file.version>4.5.0.0</file.version>
+        <file.version>4.5.1.0</file.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     </properties>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ top8.path.save=generated_top8/
 
 character-image.local-save.path=assets/characters/
 character-image.base-url=https://raw.githubusercontent.com/jonborg/ThumbnailGeneratorCharacterImageRepository/refs/heads
-character-image.version.main=/v4.5.0
+character-image.version.main=/v4.5.1
 character-image.version.backup=/master
 character-image.ssbu.render.path=/ssbu/render
 character-image.ssbu.mural.path=/ssbu/mural


### PR DESCRIPTION
- Adjusted multi character detection on Start.GG generation to be compatible with 2XKO;
- Added Galvan from ROA2;
- Added C. Viper from SF6;
- Added Armor King from Tekken 8;
- Added Lucy from Guilty Gear Strive;
- Added Joe Higashi and Chun-li from FFCOTW;
- Added Meg from GBFVR;
- Added Teemo and Warwick from 2XKO;
- Added random character selection to ROA2, SF6, TEKKEN 8, FFCOTW and 2XKO.