### PR TITLE
Increased version to 4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,9 +945,18 @@ Thumbnails are saved in **/generated_top8** folder.
 
 
 ### Release Notes
+#### v4.6.1
+- Fixed issue where if no shadow was provided to top8 slot, character image was not cropped into top8;
+- Added La Reina from Rivals of Aether 2;
+- Added Alex from Street Fighter 6;
+- Added Mr.Big and Kim Jae Hoon from Fatal Fury: COTW;
+- Changed URL name from Kim Dong Hwan to better distinguish from Kim Jae Hoon;
+- Added Ilsa from GBFVR;
+- Added Caitlyn from 2XKO.
+
 #### v4.6.0
-- Added Under Night In-Birth II Sys:Celes as a selectable game
-- Added Miary Zo from Tekken 8
+- Added Under Night In-Birth II Sys:Celes as a selectable game;
+- Added Miary Zo from Tekken 8.
 
 #### v4.5.1
 - Adjusted multi character detection on Start.GG generation to be compatible with 2XKO;

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>com.tgen</groupId>
     <artifactId>thumbnail-generator</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jdk.version>11</jdk.version>
         <project.version>${project.version}</project.version>
-        <file.version>4.6.0.0</file.version>
+        <file.version>4.6.1.0</file.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     </properties>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ top8.path.save=generated_top8/
 
 character-image.local-save.path=assets/characters/
 character-image.base-url=https://raw.githubusercontent.com/jonborg/ThumbnailGeneratorCharacterImageRepository/refs/heads
-character-image.version.main=/v4.6.0
+character-image.version.main=/v4.6.1
 character-image.version.backup=/master
 character-image.ssbu.render.path=/ssbu/render
 character-image.ssbu.mural.path=/ssbu/mural


### PR DESCRIPTION
- Fixed issue where if no shadow was provided to top8 slot, character image was not cropped into top8;
- Added La Reina from Rivals of Aether 2;
- Added Alex from Street Fighter 6;
- Added Mr.Big and Kim Jae Hoon from Fatal Fury: COTW;
- Changed URL name from Kim Dong Hwan to better distinguish from Kim Jae Hoon;
- Added Ilsa from GBFVR;
- Added Caitlyn from 2XKO.